### PR TITLE
LV2017 install successful

### DIFF
--- a/source/SystemManagementAndInformation.vipb
+++ b/source/SystemManagementAndInformation.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="0.6" Created_Date="2014-07-31 13:08:26" Modified_Date="2017-07-18 16:04:49" Creator="bmitchel" Comments="" ID="01dfdfab1cd163c4aac14564002fc5ec">
+<VI_Package_Builder_Settings Version="0.6" Created_Date="2014-07-31 13:08:26" Modified_Date="2017-07-21 11:29:49" Creator="bmitchel" Comments="" ID="4610bbe3d3c753f59c61914b34b28cf6">
   <Library_General_Settings>
     <Package_File_Name>ni_lib_smi</Package_File_Name>
-    <Library_Version>2014.0.0.14</Library_Version>
+    <Library_Version>2014.0.0.15</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..</Library_Source_Folder>
     <Library_Output_Folder>..\export</Library_Output_Folder>
@@ -61,14 +61,9 @@ sbRIO-9601, sbRIO-9602, sbRIO-9607, sbRIO-9611, sbRIO-9612, sbRIO-9627, sbRIO-96
       <Copyright/>
       <Packager>NI Systems Engineering</Packager>
       <URL>https://decibel.ni.com/content/docs/DOC-48647</URL>
-      <Release_Notes>Beta release
-
-New features: 
-Adds C Series Module Detection LV projects for generating target specific FPGA bitfiles to be used for module detection in FPGA interface mode. 
-
-Fixes (Need Validation):
-cRIO-9082 bitfile location corrected.
-Invalid property node parameter on some RIO targets.</Release_Notes>
+      <Release_Notes>New features: 
+- Adds support for NI cRIO-9032, 9035 (Sync), and 9039 (Sync) targets.
+- Adds C Series Module Detection LV projects for generating target specific FPGA bitfiles to be used for module detection in FPGA interface mode. </Release_Notes>
     </Description>
     <Destinations>
       <Toolkit_VIs>
@@ -180,9 +175,6 @@ Invalid property node parameter on some RIO targets.</Release_Notes>
       </Exclusions>
       <Exclusions>
         <Path>source/C Series module detection/lv2016</Path>
-      </Exclusions>
-      <Exclusions>
-        <Path>export</Path>
       </Exclusions>
       <Compile_Exclusions>
         <Path>cdf/C Series Module Detection</Path>
@@ -307,7 +299,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
         <Path>classes\Device\detect network devices.vi</Path>
         <VI_Title>detect network devices</VI_Title>
       </Items_Data>
-      <GUID>143FC4A5CB8A53DF8A3C9D374CF629D2</GUID>
+      <GUID>54699932F52100DE9D3C28BC2953E197</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>0</Parent_Palette_Index>
@@ -412,7 +404,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
         <Path>classes\SysCfg Device\initialize sys config device.vi</Path>
         <VI_Title>initialize device</VI_Title>
       </Items_Data>
-      <GUID>17C5A86C11C109648ED25B9AFABBEBE2</GUID>
+      <GUID>E9AE752E4308C9863846B2028D1D6702</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>1</Parent_Palette_Index>
@@ -461,7 +453,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
         <Path>get advanced system information - example.vi</Path>
         <VI_Title>advanced system information</VI_Title>
       </Items_Data>
-      <GUID>4420EE75577ECB9085191B5A411D236B</GUID>
+      <GUID>53F12F96375589B36C5593A92045C792</GUID>
     </Functions_Palette_Data>
   </Library_Palette_Definition>
 </VI_Package_Builder_Settings>


### PR DESCRIPTION
Host based C Series module detection not functional. 907x FPGA bitfile
path incorrect.